### PR TITLE
Add fetch in progress check to empty page icon

### DIFF
--- a/Dashboard/Dashboard/Presentation/DashboardView.swift
+++ b/Dashboard/Dashboard/Presentation/DashboardView.swift
@@ -48,7 +48,7 @@ public struct DashboardView: View {
                                                      withProgress: isIOS14,
                                                      refresh: true)
                     }) {
-                        if viewModel.courses.isEmpty {
+                        if !viewModel.fetchInProgress || viewModel.courses.isEmpty {
                             EmptyPageIcon()
                         } else {
                             LazyVStack(spacing: 0) {


### PR DESCRIPTION
This MR adds a check for the fetch-in-progress flag to the empty page icon. Previously, the icon would only be displayed if the courses array was empty. However, if a fetch was in progress, the user may still see a loading indicator instead of the empty page icon. With this change, if a fetch is in progress or the courses array is empty, the empty page icon will be displayed. This provides a better user experience and ensures that the empty page icon is displayed consistently.